### PR TITLE
Add vscode-include-path-fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,11 @@
         hiredis = final.callPackage ./pkgs/hiredis {};
         civetweb = final.callPackage ./pkgs/civetweb {};
         chia = nixpkgs-unstable.legacyPackages.chia;
+        vscode-include-fix = final.python38Packages.callPackage ./pkgs/vscode-include-fix {};
         python3 = prev.python3.override {
           packageOverrides = python-final: python-prev: {
             chiafan-workforce = python-final.callPackage ./pkgs/chiafan-workforce {};
             chiafan-monitor = python-final.callPackage ./pkgs/chiafan-monitor {};
-            vscode-include-fix = python-final.callPackage ./pkgs/vscode-include-fix {};
           };
         };
       };
@@ -48,7 +48,7 @@
                    civetweb = pkgs.civetweb;
                    hiredis = pkgs.hiredis;
                    redis-plus-plus = pkgs.redis-plus-plus;
-                   vscode-include-fix = pkgs.python3Packages.vscode-include-fix;
+                   vscode-include-fix = pkgs.vscode-include-fix;
                  };
 
                  devShell = pkgs.mkShell rec {

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         hiredis = final.callPackage ./pkgs/hiredis {};
         civetweb = final.callPackage ./pkgs/civetweb {};
         chia = nixpkgs-unstable.legacyPackages.chia;
-        vscode-include-fix = final.python38Packages.callPackage ./pkgs/vscode-include-fix {};
+        vscode-include-fix = final.callPackage ./pkgs/vscode-include-fix {};
         python3 = prev.python3.override {
           packageOverrides = python-final: python-prev: {
             chiafan-workforce = python-final.callPackage ./pkgs/chiafan-workforce {};

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
           packageOverrides = python-final: python-prev: {
             chiafan-workforce = python-final.callPackage ./pkgs/chiafan-workforce {};
             chiafan-monitor = python-final.callPackage ./pkgs/chiafan-monitor {};
+            vscode-include-fix = python-final.callPackage ./pkgs/vscode-include-fix {};
           };
         };
       };
@@ -47,6 +48,7 @@
                    civetweb = pkgs.civetweb;
                    hiredis = pkgs.hiredis;
                    redis-plus-plus = pkgs.redis-plus-plus;
+                   vscode-include-fix = pkgs.python3Packages.vscode-include-fix;
                  };
 
                  devShell = pkgs.mkShell rec {

--- a/pkgs/vscode-include-fix/default.nix
+++ b/pkgs/vscode-include-fix/default.nix
@@ -1,6 +1,6 @@
-{ callPackage, writeShellScriptBin, llvmPackages_11 }:
+{ python38Packages, writeShellScriptBin, llvmPackages_11 }:
 let 
-  cli = callPackage ./python-warp.nix {};
+  cli = python38Packages.callPackage ./python-warp.nix {};
 in 
   writeShellScriptBin "vscode-include-fix" ''
     ${cli}/bin/vscode-include-fix cpp-json --clang ${llvmPackages_11.clang}/bin/clang

--- a/pkgs/vscode-include-fix/default.nix
+++ b/pkgs/vscode-include-fix/default.nix
@@ -1,7 +1,7 @@
-{ callPackage, writeShellScriptBin, clang }:
+{ callPackage, writeShellScriptBin, llvmPackages_11 }:
 let 
   cli = callPackage ./python-warp.nix {};
 in 
   writeShellScriptBin "vscode-include-fix" ''
-    ${cli}/bin/vscode-include-fix cpp-json --clang ${clang}/bin/clang
+    ${cli}/bin/vscode-include-fix cpp-json --clang ${llvmPackages_11.clang}/bin/clang
   ''

--- a/pkgs/vscode-include-fix/default.nix
+++ b/pkgs/vscode-include-fix/default.nix
@@ -1,0 +1,7 @@
+{ callPackage, writeShellScriptBin, clang }:
+let 
+  cli = callPackage ./python-warp.nix {};
+in 
+  writeShellScriptBin "vscode-include-fix" ''
+    ${cli}/bin/vscode-include-fix cpp-json --clang ${clang}/bin/clang
+  ''

--- a/pkgs/vscode-include-fix/python-warp.nix
+++ b/pkgs/vscode-include-fix/python-warp.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = ./.;
 
-  propagatedBuildInputs = [ requests click ];
+  propagatedBuildInputs = [ click ];
 
-  doCheck= false;
+  doCheck = false;
 }

--- a/pkgs/vscode-include-fix/python-warp.nix
+++ b/pkgs/vscode-include-fix/python-warp.nix
@@ -1,0 +1,17 @@
+{ buildPythonPackage
+, requests
+, click
+, pandas
+, numpy
+}:
+
+buildPythonPackage rec {
+  pname = "vscode-include-fix-warp";
+  version = "1.0.0";
+
+  src = ./.;
+
+  propagatedBuildInputs = [ requests click ];
+
+  doCheck= false;
+}

--- a/pkgs/vscode-include-fix/setup.cfg
+++ b/pkgs/vscode-include-fix/setup.cfg
@@ -1,0 +1,5 @@
+[pycodestyle]
+count = False
+# ignore = E226,E302,E41
+max-line-length = 160
+statistics = True

--- a/pkgs/vscode-include-fix/setup.py
+++ b/pkgs/vscode-include-fix/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='src',
+    version="1.0.0",
+    description='python interface to vscode-include-fix',
+    author='yxb',
+
+    packages=find_packages(),
+    include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'vscode-include-fix=src.cli:main',
+        ]
+    },
+    zip_safe=False,
+    install_requires=[
+        'click',
+    ],
+    python_requires='>=3.6',
+)

--- a/pkgs/vscode-include-fix/src/__init__.py
+++ b/pkgs/vscode-include-fix/src/__init__.py
@@ -1,0 +1,3 @@
+# Placeholder
+
+

--- a/pkgs/vscode-include-fix/src/cli.py
+++ b/pkgs/vscode-include-fix/src/cli.py
@@ -1,0 +1,53 @@
+import click
+import os
+import json
+
+@click.group()
+def main():
+    pass
+
+
+@main.command()
+@click.option('clang_path', '--clang',
+              help = 'The clang bin path',
+              type = click.STRING,
+              default= '/nix/store/p5w6pzixrxzikq4vjvkzg7xccwwbvanv-clang-wrapper-11.1.0/bin/clang')
+def cpp_json(clang_path: str):
+    include_path_env = os.getenv('CMAKE_INCLUDE_PATH')
+    if include_path_env == None:
+      print("CMAKE_INCLUDE_PATH has no content.")
+      return 
+    include_paths = list(set(include_path_env.split(':')))
+    print(include_paths)
+    
+    js = {
+      "configurations": [
+          {
+            "name": "Linux",
+            "includePath": [
+              "${workspaceFolder}/**"
+            ],
+            "defines": [
+              "SPDLOG_FMT_EXTERNAL"
+            ],
+            "compilerPath": clang_path,
+            "cStandard": "c17",
+            "cppStandard": "c++20",
+            "intelliSenseMode": "linux-clang-x64"
+          }
+      ],
+      "version": 4
+    }
+    print(js)
+    for e in include_paths:
+      js['configurations'][0]['includePath'].append(e)
+
+    if not os.path.exists('.vscode'):
+      os.makedirs('.vscode')
+
+    with open('.vscode/c_cpp_properties.json', 'w') as fp:
+      json.dump(js, fp, indent=4)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
backgroud:
  vscode 如果没有写上include path 会有很多错误曲线 并且不能 Ctrl+左键 进入函数的定义。这让开发体验很差。
  虽然 vscode 的扩展 cmake tools 能自动配置 include path ， 但是在 nix develop下， cmake tools 不能用。
  
solution： 
  1. 进入nix develop后把 CMAKE_INCLUDE_PATH 里面的内容 添加到 vscode include path.
  方案1有一个明显的缺点，就是一旦 CMAKE_INCLUDE_PATH 里面的东西有变化（比如basis更新），就得重新操作。
  2. 写一个 脚本自动完成 方案1

这个 PR 做得就是方案2

使用方法：
  在需要的 repo 的 devShell 里面添加 vscode-include-fix。 然后进入nix develop 后 敲击 vscode-include-fix 即可自动配置好vscode 的 include path
  