### PR TITLE
InfluxDB Query needs boost

### DIFF
--- a/pkgs/influxdb-cxx/default.nix
+++ b/pkgs/influxdb-cxx/default.nix
@@ -24,8 +24,6 @@ llvmPackages_11.stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DINFLUXCXX_WITH_BOOST=ON"
-    "-DINFLUXCXX_TESTING=ON"
   ];
 
   meta = with lib; {

--- a/pkgs/influxdb-cxx/default.nix
+++ b/pkgs/influxdb-cxx/default.nix
@@ -24,7 +24,7 @@ llvmPackages_11.stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DINFLUXCXX_WITH_BOOST=OFF"
+    "-DINFLUXCXX_TESTING=OFF"
   ];
 
   meta = with lib; {

--- a/pkgs/influxdb-cxx/default.nix
+++ b/pkgs/influxdb-cxx/default.nix
@@ -24,6 +24,7 @@ llvmPackages_11.stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
+    "-DINFLUXCXX_WITH_BOOST=OFF"
   ];
 
   meta = with lib; {

--- a/pkgs/influxdb-cxx/default.nix
+++ b/pkgs/influxdb-cxx/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , cmake
 , curl
+, boost17x
 }:
 
 llvmPackages_11.stdenv.mkDerivation rec {
@@ -19,11 +20,12 @@ llvmPackages_11.stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     curl
+    (boost17x.override { enablePython = true; extraB2Args = [ " --with-locale stage " ]; })
   ];
 
   cmakeFlags = [
-    "-DINFLUXCXX_WITH_BOOST=OFF"
-    "-DINFLUXCXX_TESTING=OFF"
+    "-DINFLUXCXX_WITH_BOOST=ON"
+    "-DINFLUXCXX_TESTING=ON"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
While using influxDB, it works fine with writing data and creating database, but it will crash when query data. 
After adding boost to nix, it works just fine.